### PR TITLE
Steam startup fix

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -509,7 +509,7 @@ namespace The_Ezio_Trilogy_Launcher
                     }
                     Log.Information("Game started");
                     Log.Information("Waiting for game to be closed");
-                    await Task.Delay(10000);
+                    await Task.Delay(50000);
                     while (gameProcesses.Length > 0)
                     {
                         await Task.Delay(1000);


### PR DESCRIPTION
When launching Assassins creed 2 through steam an extra handshake has to occur between steam and ubisoft connect. Due to this, umod was exiting before the game had time to open and the textures were not injected.

A demonstration of this can be seen in the following [video](https://www.youtube.com/watch?v=regksPf467A). The console states that the game has closed and the playstation textures are not applied.

I found that the opening time varied quite a bit and I adjusted the delay time to try and strike a balance between allowing enough time for steam to sort itself out but also not wait too long.

